### PR TITLE
Added params option

### DIFF
--- a/lib/tencent_cos_sdk/request.rb
+++ b/lib/tencent_cos_sdk/request.rb
@@ -4,7 +4,7 @@ require 'tencent_cos_sdk/utils'
 
 module TencentCosSdk
     class Request
-        attr_accessor :http_method, :path, :headers, :body, :file
+        attr_accessor :http_method, :path, :headers, :params, :body, :file
         attr_accessor :response, :time_used
         attr_accessor :options
 
@@ -14,6 +14,7 @@ module TencentCosSdk
             self.http_method    = options[:http_method]
             self.path           = options[:path]
             self.headers        = options[:headers] || {}
+            self.params         = options[:params]
             self.body           = options[:body]
             self.file           = options[:file]
 
@@ -34,6 +35,7 @@ module TencentCosSdk
                     verify_ssl: false
                 }
 
+                options[:headers][:params] = params if params
                 options[:payload] = body            if body
                 options[:payload] = IO.binread file if file
 

--- a/lib/tencent_cos_sdk/utils.rb
+++ b/lib/tencent_cos_sdk/utils.rb
@@ -41,14 +41,20 @@ module TencentCosSdk
             http_string += get_headers + "\n"
         end
 
-        # NOTE: 暂不需要
         def get_params
-            ''
+            return '' if !params
+
+            params.map do |k, v|
+                "#{k.downcase}=#{CGI::escape(v)}"
+            end.sort.join('&')
         end
 
-        # NOTE: 暂不需要
         def get_param_list
-            ''
+            return '' if !params
+
+            params.map do |k, v|
+                k.downcase
+            end.sort.join(';')
         end
 
         def get_headers

--- a/test/tencent_cos_sdk_test.rb
+++ b/test/tencent_cos_sdk_test.rb
@@ -39,6 +39,13 @@ class TencentCosSdkTest < Minitest::Test
         assert_equal 200, response.code
     end
 
+    def test_get_with_params
+        TencentCosSdk.put @path, body: 'abc123'
+
+        response = TencentCosSdk.get @path, params: { prefix: "#{File.dirname(@path)}/", delimiter: '/' }
+        assert_equal 200, response.code
+    end
+
     def test_delete
         TencentCosSdk.put @path, body: 'abc123'
 


### PR DESCRIPTION
Hi @xxjapp 
Thanks for wonderful gem.

I want to call GET Bucket API.
https://intl.cloud.tencent.com/document/product/436/7734

This API requires query parameters, so I added params option.


Can you please review it?